### PR TITLE
Don't upload to WD items that have multiple selibrs

### DIFF
--- a/importer/Person.py
+++ b/importer/Person.py
@@ -162,19 +162,20 @@ class Person(WikidataItem):
         uri_match = self.existing.get(uri)
         selibr_match = selibrs.get(selibr)
 
+        if uri_match:
+            self.associate_wd_item(uri_match)
         #  If there's more than one selibr-key associated
         #  with a Q number, exclude this object from the upload.
         #  That way we avoid editing WD items with multiple
         #  P906 (error either on WD or in Libris)
-        if len([x for x in selibrs.keys()
-                if selibrs[x] == selibr_match]) > 1:
-            self.set_upload(False)
-            return
-
-        if uri_match:
-            self.associate_wd_item(uri_match)
         elif selibr_match:
-            self.associate_wd_item(selibr_match)
+            selibrs_on_this_q = [x for x in selibrs.keys()
+                                 if selibrs[x] == selibr_match]
+            if len(selibrs_on_this_q) > 1:
+                self.set_upload(False)
+                return
+            else:
+                self.associate_wd_item(selibr_match)
 
     def set_timestamp(self):
         """Get timestamp of last change of post."""

--- a/importer/WikidataItem.py
+++ b/importer/WikidataItem.py
@@ -118,6 +118,9 @@ class WikidataItem(object):
         if wd_item is not None:
             self.wd_item["wd-item"] = wd_item
 
+    def set_upload(self, booln):
+        self.wd_item["upload"] = booln
+
     def add_label(self, language, text):
         base = self.wd_item["labels"]
         base.append({"language": language, "value": text})


### PR DESCRIPTION
Some WD items have multiple SELIBR id's. The error either comes from Libris
or was introduced directly on Wikidata. Either way, we don't want to edit
those items.

Switch off the upload flag for Libris objects with a SELIBR that is associated with a WD item
that has more than one SELIBR.

Task: https://phabricator.wikimedia.org/T202606