### PR TITLE
Don't create new WD items

### DIFF
--- a/importer/Person.py
+++ b/importer/Person.py
@@ -171,11 +171,12 @@ class Person(WikidataItem):
         elif selibr_match:
             selibrs_on_this_q = [x for x in selibrs.keys()
                                  if selibrs[x] == selibr_match]
-            if len(selibrs_on_this_q) > 1:
-                self.set_upload(False)
-                return
-            else:
+            if len(selibrs_on_this_q) == 1:
                 self.associate_wd_item(selibr_match)
+            else:
+                self.set_upload(False)
+        else:
+            self.set_upload(False)
 
     def set_timestamp(self):
         """Get timestamp of last change of post."""

--- a/importer/Uploader.py
+++ b/importer/Uploader.py
@@ -93,4 +93,5 @@ class Uploader(object):
         print("---------------")
         self.data = data_object.wd_item
         self.wdstuff = WDS(self.repo, edit_summary=self.summary)
-        self.set_wd_item()
+        if self.data["upload"]:
+            self.set_wd_item()


### PR DESCRIPTION
Disable creating new items.

We're only dealing with already existing Selibr-items in the
foreseeable future, so unmatched items will not be uploaded.

Task: https://phabricator.wikimedia.org/T202965