### PR TITLE
Process full auth dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ Tools for the Library Data 2018 project @ Wikimedia Sverige.
 
 ## Import of Libris URI's
 
-* **importer/process_auth.py** – taking a single New Libris Authority post, either in a local file or online, match with a Wikidata item with a corresponding Selibr ID and add Libris URI to it.
+* **importer/process_auth.py** – taking a directory of Libris authority posts (one json-ld object per file), match with Wikidata items with corresponding Selibr ID's and add Libris URI to it.
 
 ```
-python3 importer/process_auth.py --uri xxxxxx --upload live
+python3 importer/process_auth.py --dir librisfiles/ --upload live
 ```
 
 ## Data pre-processing

--- a/importer/Person.py
+++ b/importer/Person.py
@@ -136,15 +136,15 @@ class Person(WikidataItem):
         in the dump. These seem to be recently created
         items, from summer 2018 onwards, i.e. probably
         native "new Libris" objects, not imported.
+        For these we only add retrieval date.
         """
         uri = self.raw_data[0]["@id"].split("/")[-1]
         url = self.URL_BASE.format(uri)
 
+        publication_date = None
         modified = self.raw_data[0].get("modified")
         if modified:
             publication_date = modified.split("T")[0]
-        else:
-            publication_date = self.DUMP_DATE
 
         self.source = self.make_stated_in_ref("Q1798125",
                                               publication_date,

--- a/importer/Person.py
+++ b/importer/Person.py
@@ -9,6 +9,7 @@ class Person(WikidataItem):
     """A person as represented in Libris."""
 
     URL_BASE = "https://libris.kb.se/katalogisering/{}"
+    DUMP_DATE = "2018-08-24"
 
     def set_is(self):
         """Set is as a person."""
@@ -36,7 +37,7 @@ class Person(WikidataItem):
     def set_uri(self):
         """Set Libris URI."""
         uri = self.raw_data[0]["@id"].split("/")[-1]
-        self.add_statement("libris_uri", uri)
+        self.add_statement("libris_uri", uri, ref=self.source)
 
     def set_selibr(self):
         """Set Selibr identifier."""
@@ -127,18 +128,27 @@ class Person(WikidataItem):
                 self.add_statement("citizenship", country, ref=self.source)
 
     def create_sources(self):
-        """Create a stated in reference."""
-        retrieval_date = "2018-08-24"
+        """
+        Create a stated in reference.
+
+        Note that some objects do not have last
+        modification date, or any other date,
+        in the dump. These seem to be recently created
+        items, from summer 2018 onwards, i.e. probably
+        native "new Libris" objects, not imported.
+        """
         uri = self.raw_data[0]["@id"].split("/")[-1]
         url = self.URL_BASE.format(uri)
 
         modified = self.raw_data[0].get("modified")
         if modified:
             publication_date = modified.split("T")[0]
+        else:
+            publication_date = self.DUMP_DATE
 
         self.source = self.make_stated_in_ref("Q1798125",
                                               publication_date,
-                                              url, retrieval_date)
+                                              url, self.DUMP_DATE)
 
     def match_wikidata(self):
         """
@@ -190,7 +200,7 @@ class Person(WikidataItem):
         WikidataItem.__init__(self, raw_data, repository, data_files, existing)
         self.raw_data = raw_data["@graph"]
         self.data_files = data_files
-        # self.create_sources()
+        self.create_sources()
 
         # self.set_ids()
         # self.set_selibr()

--- a/importer/Person.py
+++ b/importer/Person.py
@@ -128,11 +128,14 @@ class Person(WikidataItem):
 
     def create_sources(self):
         """Create a stated in reference."""
+        retrieval_date = "2018-08-23"  # replace date of the dump
         uri = self.raw_data[0]["@id"].split("/")[-1]
         url = self.URL_BASE.format(uri)
 
-        publication_date = self.timestamp
-        retrieval_date = "2018-08-23"  # replace date of the dump
+        modified = self.raw_data[0].get("modified")
+        if modified:
+            publication_date = modified.split("T")[0]
+
         self.source = self.make_stated_in_ref("Q1798125",
                                               publication_date,
                                               url, retrieval_date)
@@ -186,7 +189,6 @@ class Person(WikidataItem):
         """Initialize an empty object."""
         WikidataItem.__init__(self, raw_data, repository, data_files, existing)
         self.raw_data = raw_data["@graph"]
-        self.set_timestamp()
         self.data_files = data_files
         self.create_sources()
 

--- a/importer/Person.py
+++ b/importer/Person.py
@@ -36,7 +36,7 @@ class Person(WikidataItem):
     def set_uri(self):
         """Set Libris URI."""
         uri = self.raw_data[0]["@id"].split("/")[-1]
-        self.add_statement("libris_uri", uri, ref=self.source)
+        self.add_statement("libris_uri", uri)
 
     def set_selibr(self):
         """Set Selibr identifier."""
@@ -190,7 +190,7 @@ class Person(WikidataItem):
         WikidataItem.__init__(self, raw_data, repository, data_files, existing)
         self.raw_data = raw_data["@graph"]
         self.data_files = data_files
-        self.create_sources()
+        # self.create_sources()
 
         # self.set_ids()
         # self.set_selibr()

--- a/importer/WikidataItem.py
+++ b/importer/WikidataItem.py
@@ -80,15 +80,17 @@ class WikidataItem(object):
 
     def make_stated_in_ref(self,
                            value,
-                           pub_date,
+                           pub_date=None,
                            ref_url=None,
                            retrieved_date=None):
         item_prop = self.props["stated_in"]
         published_prop = self.props["publication_date"]
-        pub_date = utils.date_to_dict(pub_date, "%Y-%m-%d")
-        timestamp = self.make_pywikibot_item({"date_value": pub_date})
-        published_claim = self.wdstuff.make_simple_claim(
-            published_prop, timestamp)
+        published_claim = None
+        if pub_date:
+            pub_date = utils.date_to_dict(pub_date, "%Y-%m-%d")
+            timestamp = self.make_pywikibot_item({"date_value": pub_date})
+            published_claim = self.wdstuff.make_simple_claim(
+                published_prop, timestamp)
         source_item = self.wdstuff.QtoItemPage(value)
         source_claim = self.wdstuff.make_simple_claim(item_prop, source_item)
         if ref_url and retrieved_date:
@@ -104,9 +106,14 @@ class WikidataItem(object):
             retrieved_on_claim = self.wdstuff.make_simple_claim(
                 retrieved_date_prop, retrieved_date)
 
-            ref = self.wdstuff.Reference(
-                source_test=[source_claim, ref_url_claim],
-                source_notest=[published_claim, retrieved_on_claim])
+            if published_claim:
+                ref = self.wdstuff.Reference(
+                    source_test=[source_claim, ref_url_claim],
+                    source_notest=[published_claim, retrieved_on_claim])
+            else:
+                ref = self.wdstuff.Reference(
+                    source_test=[source_claim, ref_url_claim],
+                    source_notest=[retrieved_on_claim])
         else:
             ref = self.wdstuff.Reference(
                 source_test=[source_claim],


### PR DESCRIPTION
Implement handling of local directory full of files.

Remove online data handling. Loop over a directory of
files instead.

Make the reference handling more flexible, since some of the
newer Libris entries (possibly native Libris 2, not imported)
don't have timestamps in the json dump.

Task: https://phabricator.wikimedia.org/T202487