### PR TITLE
Check that external ID is not broken

### DIFF
--- a/importer/Person.py
+++ b/importer/Person.py
@@ -76,7 +76,8 @@ class Person(WikidataItem):
         if bio_section.get("identifiedBy"):
             for i in bio_section.get("identifiedBy"):
                 if (i["@type"] == "Identifier" and
-                        i["typeNote"] in allowed_types):
+                        i["typeNote"] in allowed_types and
+                        i.get("value")):
                     if i["typeNote"] == "isni":
                         i["value"] = utils.format_isni(i["value"])
                     self.add_statement(i["typeNote"],


### PR DESCRIPTION
Implement error handling for malformed external ID's.

A broken ISNI was found in https://libris.kb.se/katalogisering/lvp2ktrjj0v9dr31.
A missing "value" field for VIAF/ISNI should not crash the script.

Task: https://phabricator.wikimedia.org/T204104