### PR TITLE
Handle malformed hyphen in life range

### DIFF
--- a/importer/Person.py
+++ b/importer/Person.py
@@ -130,7 +130,7 @@ class Person(WikidataItem):
         bio_section = self.raw_data[1]
         if not bio_section.get("lifeSpan"):
             return
-        life = bio_section["lifeSpan"].split("-")
+        life = bio_section["lifeSpan"].replace("–", "-").split("-")
         born_raw = life[0]
         dead_raw = life[1]
         if len(born_raw) == 4:


### PR DESCRIPTION
See e.g. https://libris.kb.se/katalogisering/75knvlrr034g8vb – the life years 1864–1945 contain an n-dash instead of the customary hyphen, making it impossible to process.

Add support of n-dash as valid year delimiter.

Task: https://phabricator.wikimedia.org/T205371