### PR TITLE
Exclude lifespans without numbers

### DIFF
--- a/importer/Person.py
+++ b/importer/Person.py
@@ -123,6 +123,8 @@ class Person(WikidataItem):
             return False
         if any(keyword in lifespan for keyword in bad_keywords):
             return False
+        if not any(char.isdigit() for char in lifespan):
+            return False
         return True
 
     def clean_up_lifespan(self, lifespan):


### PR DESCRIPTION
Don't process lifespan fields that don't contain any numbers.

There are some entries with erroneous input in lifespan, e. g.
https://libris.kb.se/katalogisering/jgvx1zn21x6ppsc

Task: https://phabricator.wikimedia.org/T205614