### PR TITLE
Optimize querying for surname

### DIFF
--- a/importer/Person.py
+++ b/importer/Person.py
@@ -25,6 +25,7 @@ class Person(WikidataItem):
 
     def add_to_cache(self, cache_name, raw_data, match):
         """Add a raw_data : match pair to cache."""
+        print(self.caches[cache_name])
         self.caches[cache_name][raw_data] = match
 
     def set_surname(self):

--- a/importer/Person.py
+++ b/importer/Person.py
@@ -24,9 +24,15 @@ class Person(WikidataItem):
         return self.raw_data[1].get("familyName")
 
     def add_to_cache(self, cache_name, raw_data, match):
+        """Add a raw_data : match pair to cache."""
         self.caches[cache_name][raw_data] = match
 
     def set_surname(self):
+        """
+        Set surname.
+
+        Use the cache if possible, otherwise query Wikidata.
+        """
         raw_surname = self.get_last_name()
         if (not raw_surname or
                 not self.nationality_in_latin_country()):

--- a/importer/Person.py
+++ b/importer/Person.py
@@ -25,7 +25,6 @@ class Person(WikidataItem):
 
     def add_to_cache(self, cache_name, raw_data, match):
         """Add a raw_data : match pair to cache."""
-        print(self.caches[cache_name])
         self.caches[cache_name][raw_data] = match
 
     def set_surname(self):

--- a/importer/WikidataItem.py
+++ b/importer/WikidataItem.py
@@ -24,6 +24,9 @@ class WikidataItem(object):
 
         self.problem_report = {}
 
+    def get_caches(self):
+        return self.caches
+
     def make_q_item(self, qnumber):
         return self.wdstuff.QtoItemPage(qnumber)
 

--- a/importer/WikidataItem.py
+++ b/importer/WikidataItem.py
@@ -12,11 +12,12 @@ DATA_DIR = "data"
 
 class WikidataItem(object):
 
-    def __init__(self, db_row_dict, repository, data_files, existing):
+    def __init__(self, db_row_dict, repository, data_files, existing, caches):
         self.repo = repository
         self.existing = existing
         self.wdstuff = WDS(self.repo)
         self.raw_data = db_row_dict
+        self.caches = caches
         self.problem_report = {}
         self.props = data_files["properties"]
         self.construct_wd_item()

--- a/importer/process_auth.py
+++ b/importer/process_auth.py
@@ -107,6 +107,7 @@ def main(arguments):
                             data_files,
                             existing_people,
                             cache)
+            cache = person.get_caches()
             problem_report = person.get_report()
             if arguments.get("upload"):
                 live = True if arguments["upload"] == "live" else False

--- a/importer/process_auth.py
+++ b/importer/process_auth.py
@@ -24,6 +24,7 @@ from Uploader import Uploader
 EDIT_SUMMARY = "#WMSE #LibraryData_KB"
 MAPPINGS = "mappings"
 REPORTING_DIR = "reports"
+CACHE = "cache"
 
 
 def make_filenames(timestamp):
@@ -85,9 +86,25 @@ def list_available_files(path, limit=None, uri=None):
     return files
 
 
+def load_caches(keys):
+    cache = {}
+    for k in keys:
+        fpath = os.path.join(CACHE, "{}.json".format(k))
+        if os.path.exists(fpath):
+            cache[k] = utils.load_json(fpath)
+        else:
+            cache[k] = {}
+    return cache
+
+
+def dump_caches(wditem_caches):
+    for cache in wditem_caches:
+        fname = os.path.join(CACHE, "{}.json".format(cache))
+        utils.json_to_file(fname, wditem_caches[cache])
+
+
 def main(arguments):
     """Get arguments and process data."""
-    cache = {"surname": {}}
     libris_files = list_available_files(arguments.get("dir"),
                                         arguments.get("limit"),
                                         arguments.get("uri"))
@@ -101,13 +118,14 @@ def main(arguments):
 
     for fname in libris_files:
         data = utils.load_json(fname)
+        cache = load_caches(["surname"])
         if is_person(data):
             person = Person(data,
                             wikidata_site,
                             data_files,
                             existing_people,
                             cache)
-            cache = person.get_caches()
+            dump_caches(person.get_caches())
             problem_report = person.get_report()
             if arguments.get("upload"):
                 live = True if arguments["upload"] == "live" else False

--- a/importer/process_auth.py
+++ b/importer/process_auth.py
@@ -87,6 +87,7 @@ def list_available_files(path, limit=None, uri=None):
 
 def main(arguments):
     """Get arguments and process data."""
+    cache = {"surname": {}}
     libris_files = list_available_files(arguments.get("dir"),
                                         arguments.get("limit"),
                                         arguments.get("uri"))
@@ -101,7 +102,11 @@ def main(arguments):
     for fname in libris_files:
         data = utils.load_json(fname)
         if is_person(data):
-            person = Person(data, wikidata_site, data_files, existing_people)
+            person = Person(data,
+                            wikidata_site,
+                            data_files,
+                            existing_people,
+                            cache)
             problem_report = person.get_report()
             if arguments.get("upload"):
                 live = True if arguments["upload"] == "live" else False


### PR DESCRIPTION
Implement caching for surname matches.

A basic cache functionality consisting of a cache object in WikidataItem
which is read by process_auth.py after every item in the loop.
Additionally, the cache is dumped to a file after every item.
This means that when re-running the script, the names that got matched
in the previous run don't have to be queried for again, which further
makes the execution faster.

Mechanism for adding values to cache is only implemented in
Person.py. If it works satisfactorily it can be moved to WikidataItem later.

Task: https://phabricator.wikimedia.org/T205276