### PR TITLE
Libris URI to WD item

### DIFF
--- a/importer/Edition.py
+++ b/importer/Edition.py
@@ -11,6 +11,10 @@ class Edition(WikidataItem):
     URL_BASE = "https://libris.kb.se/katalogisering/{}"
     DUMP_DATE = "2018-08-24"  # update when dump
 
+    def set_is(self):
+        edition = "Q3331189"
+        self.add_statement("is", edition)
+
     def match_wikidata(self):
         uri = self.raw_data[0]["@id"].split("/")[-1]
         uri_match = self.existing.get(uri)
@@ -34,3 +38,4 @@ class Edition(WikidataItem):
 
         self.match_wikidata()
         self.set_uri()
+        self.set_is()

--- a/importer/Edition.py
+++ b/importer/Edition.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python
+# -*- coding: utf-8  -*-
+"""An object representing a Libris edition item."""
+from WikidataItem import WikidataItem
+import importer_utils as utils
+
+
+class Edition(WikidataItem):
+    """An Edition as represented in Libris."""
+
+    URL_BASE = "https://libris.kb.se/katalogisering/{}"
+    DUMP_DATE = "2018-08-24"  # update when dump
+
+    def __init__(self, raw_data, repository, data_files, existing, cache):
+        """Initialize an empty object."""
+        WikidataItem.__init__(self,
+                              raw_data,
+                              repository,
+                              data_files,
+                              existing,
+                              cache)
+        self.raw_data = raw_data["@graph"]
+        self.data_files = data_files

--- a/importer/Edition.py
+++ b/importer/Edition.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8  -*-
 """An object representing a Libris edition item."""
 from WikidataItem import WikidataItem
-import importer_utils as utils
+# import importer_utils as utils
 
 
 class Edition(WikidataItem):
@@ -10,6 +10,16 @@ class Edition(WikidataItem):
 
     URL_BASE = "https://libris.kb.se/katalogisering/{}"
     DUMP_DATE = "2018-08-24"  # update when dump
+
+    def match_wikidata(self):
+        uri = self.raw_data[0]["@id"].split("/")[-1]
+        uri_match = self.existing.get(uri)
+        if uri_match:
+            self.associate_wd_item(uri_match)
+
+    def set_uri(self):
+        uri = self.raw_data[0]["@id"].split("/")[-1]
+        self.add_statement("libris_uri", uri)
 
     def __init__(self, raw_data, repository, data_files, existing, cache):
         """Initialize an empty object."""
@@ -21,3 +31,6 @@ class Edition(WikidataItem):
                               cache)
         self.raw_data = raw_data["@graph"]
         self.data_files = data_files
+
+        self.match_wikidata()
+        self.set_uri()

--- a/importer/process_edition.py
+++ b/importer/process_edition.py
@@ -54,7 +54,6 @@ def main(arguments):
         if "Q" in problem_report and problem_report["Q"] == "":
             problem_report["Q"] = uploader.wd_item_q
         try:
-            print("Gonna upload")
             uploader.upload()
         except pywikibot.data.api.APIError as e:
             print(e)

--- a/importer/process_edition.py
+++ b/importer/process_edition.py
@@ -1,0 +1,27 @@
+#!/usr/bin/python
+# -*- coding: utf-8  -*-
+import argparse
+import os
+import pywikibot
+import importer_utils as utils
+
+import importer_utils as utils
+from Edition import Edition
+from Uploader import Uploader
+
+
+def main():
+    return
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    # parser.add_argument("--dir", required=True)
+    parser.add_argument("--uri")
+    parser.add_argument("--upload", action='store')
+    parser.add_argument("--limit",
+                        nargs='?',
+                        type=int,
+                        action='store')
+    args = parser.parse_args()
+    main(vars(args))

--- a/importer/process_edition.py
+++ b/importer/process_edition.py
@@ -1,17 +1,63 @@
 #!/usr/bin/python
 # -*- coding: utf-8  -*-
 import argparse
+import json
 import os
 import pywikibot
+import requests
 import importer_utils as utils
 
-import importer_utils as utils
+
 from Edition import Edition
 from Uploader import Uploader
 
+MAPPINGS = "mappings"
+EDIT_SUMMARY = "#WMSE #LibraryData_KB"
 
-def main():
-    return
+
+def load_mapping_files():
+    """Load local and remote mapping files."""
+    mappings = {}
+    local = ["properties"]
+    remote = []
+    for title in local:
+        f = os.path.join(MAPPINGS, '{}.json'.format(title))
+        mappings[title] = utils.load_json(f)
+    for title in remote:
+        mappings[title] = utils.get_wd_items_using_prop(
+            mappings["properties"][title])
+    print("Loaded local mappings: {}.".format(", ".join(local)))
+    print("Loaded remote mappings: {}.".format(", ".join(remote)))
+    return mappings
+
+
+def get_from_uri(uri):
+    """Load data from uri."""
+    url = "https://libris.kb.se/{}/data.jsonld".format(uri)
+    return json.loads(requests.get(url).text)
+
+
+def main(arguments):
+    data = get_from_uri(arguments.get("uri"))
+    data_files = load_mapping_files()
+    cache = {}
+    existing_editions = utils.get_wd_items_using_prop(
+        data_files["properties"]["libris_uri"])
+    wikidata_site = utils.create_site_instance("wikidata", "wikidata")
+    edition = Edition(data, wikidata_site, data_files,
+                      existing_editions, cache)
+    problem_report = edition.get_report()
+    if arguments.get("upload"):
+        live = True if arguments["upload"] == "live" else False
+        uploader = Uploader(edition, repo=wikidata_site,
+                            live=live, edit_summary=EDIT_SUMMARY)
+        if "Q" in problem_report and problem_report["Q"] == "":
+            problem_report["Q"] = uploader.wd_item_q
+        try:
+            print("Gonna upload")
+            uploader.upload()
+        except pywikibot.data.api.APIError as e:
+            print(e)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Start implementing tool that takes one Libris URI as input and
creates/matches WD item.
Current functionalities: create item or match with existing via Libris URI;
add Libris URI; add P31 = edition.

Task: https://phabricator.wikimedia.org/T206980