### PR TITLE
Make sure adding pages only adds pages

### DIFF
--- a/importer/Edition.py
+++ b/importer/Edition.py
@@ -241,6 +241,7 @@ class Edition(WikidataItem):
         exactly one numeric content.
         """
         extent = self.raw_data[1].get("extent")
+        required = ["s.", "s", "sidor", "sid", "sid."]
         if len(extent) != 1:
             return
         if extent[0].get("label"):
@@ -248,7 +249,8 @@ class Edition(WikidataItem):
             if len(extent_labels) != 1:
                 return
             number_strings = re.findall(r"\d+", extent_labels[0])
-            if len(number_strings) == 1:
+            if (len(number_strings) == 1 and
+                    any(x in number_strings[0] for x in required)):
                 no_pages = utils.package_quantity(number_strings[0])
                 self.add_statement("pages", no_pages, ref=self.source)
 


### PR DESCRIPTION
Since the `Extent` field can contain other data than the number of pages, such as number of volumes, etc – and they're not tagged further – make sure that you're actually adding the number of pages with the number of pages property.

Task: https://phabricator.wikimedia.org/T207275