### PR TITLE
Only upload if entry belongs to NB

### DIFF
--- a/importer/Edition.py
+++ b/importer/Edition.py
@@ -23,13 +23,11 @@ class Edition(WikidataItem):
         """Only upload if entry belongs to National Bibliography."""
         self.set_upload(False)
         bibliography = self.raw_data[0].get("bibliography")
-        print(bibliography)
-        if bibliography:
-            for el in bibliography:
-                print(el)
-                if el.get("@type") == "Library" and el.get("sigel") == "NB":
-                    print("Book is in NB.")
-                    self.set_upload(True)
+        if not bibliography:
+            return
+        for el in bibliography:
+            if el.get("@type") == "Library" and el.get("sigel") == "NB":
+                self.set_upload(True)
 
     def match_wikidata(self):
         match_found = False

--- a/importer/Edition.py
+++ b/importer/Edition.py
@@ -19,6 +19,18 @@ class Edition(WikidataItem):
         edition = "Q3331189"
         self.add_statement("is", edition)
 
+    def upload_if_nb(self):
+        """Only upload if entry belongs to National Bibliography."""
+        self.set_upload(False)
+        bibliography = self.raw_data[0].get("bibliography")
+        print(bibliography)
+        if bibliography:
+            for el in bibliography:
+                print(el)
+                if el.get("@type") == "Library" and el.get("sigel") == "NB":
+                    print("Book is in NB.")
+                    self.set_upload(True)
+
     def match_wikidata(self):
         match_found = False
         uri = self.raw_data[0]["@id"].split("/")[-1]
@@ -381,6 +393,7 @@ class Edition(WikidataItem):
         self.set_uri()
         self.set_libris()
         self.set_isbn()
+        self.upload_if_nb()
         self.set_is()
         self.set_language()
         self.set_contributors()


### PR DESCRIPTION
Check whether this book belongs to the National Bibliography. If it does not, disable the upload flag.

At this point, NB is the only dataset with clear copyright status (CC0).