### PR TITLE
Tool to perform an Xsearch query

### DIFF
--- a/Biblioteksdata2/xsearch.py
+++ b/Biblioteksdata2/xsearch.py
@@ -1,0 +1,116 @@
+#!/usr/bin/python
+# -*- coding: utf-8  -*-
+"""Download results of API call to Libris xsearch API.
+
+Xsearch query codes:
+http://librishelp.libris.kb.se/help/search_codes_swe.jsp
+
+Script follows pagination in the result
+and saves the final output to a json file.
+"""
+import argparse
+import json
+import requests
+
+BASEURL = "http://libris.kb.se/xsearch?query={}&format=json&n=200&start={}"
+
+SAVEFILE = "xsearch.json"
+
+
+def permissive_json_loads(text):
+    """
+    Load json with possible unescaped chars.
+
+    https://stackoverflow.com/a/42208862/12214611
+
+    We encountered some unescaped backslashes
+    in the Libris data, which break the
+    json parsing. This escapes them
+    while reading the text chunk.
+
+    @param text: text to parse as json
+    @type text: string
+    """
+    while True:
+        try:
+            data = json.loads(text)
+        except ValueError as exc:
+            if exc.msg == 'Invalid \\escape':
+                text = text[:exc.pos] + '\\' + text[exc.pos:]
+            else:
+                raise
+        else:
+            return data
+
+
+def get_from_url(url):
+    """
+    Retrieve json content from url.
+
+    @param url: url to fetch data from
+    @type url: string
+    """
+    content = requests.get(url).text
+    return permissive_json_loads(content)
+
+
+def json_to_file(filename, content):
+    """
+    Pretty write json object to file.
+
+    @param filename: file to save to
+    @type filename: string
+    @param content: content to save
+    @type content: dictionary
+    """
+    with open(filename, 'w') as f:
+        json.dump(content, f, indent=4,
+                  separators=(',', ': '),
+                  sort_keys=True)
+        f.write('\n')
+    print("Saved {} objects to {}".format(len(content), filename))
+
+
+def harvest_query(query):
+    """
+    Harvest results of API call.
+
+    @param query: Libris xsearch query
+    @type query: string
+    @return API call result as JSON object
+    """
+    harvest = []
+    url = BASEURL.format(query, "1")
+    content = get_from_url(url)
+    total_hits = content["xsearch"]["records"]
+    harvest.extend(content["xsearch"]["list"])
+    print("Running query: {}.".format(query))
+    print("{} objects to harvest.".format(total_hits))
+    print("Harvested: {} objects.".format(len(harvest)))
+    while len(harvest) < total_hits:
+        to_record = int(content["xsearch"]["to"])
+        from_record = to_record + 1
+        url = "=".join(url.split("=")[:-1]) + "={}".format(from_record)
+        content = get_from_url(url)
+        harvest.extend(content["xsearch"]["list"])
+        print("Harvested: {} objects.".format(len(harvest)))
+    return harvest
+
+
+def main(args):
+    """Read arguments and run API call."""
+    if args["file"]:
+        filename = "{}.json".format(args["file"])
+    else:
+        filename = SAVEFILE
+    if args["query"]:
+        harvest = harvest_query(args["query"])
+        json_to_file(filename, harvest)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--query", required=True)
+    parser.add_argument("--file")
+    args = parser.parse_args()
+    main(vars(args))

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017
+Copyright (c) 2019
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # Biblioteksdata
 
-Tools for the Library Data 2018 project @ Wikimedia Sverige.
+Tools for the Library Data 2018–2019 project @ Wikimedia Sverige.
+
+## Download results of xsearch search
+
+`Biblioteksdata2/xsearch.py` performs a search in the Libris API using [xsearch codes](http://librishelp.libris.kb.se/help/search_codes_swe.jsp).
+
+Usage:
+
+```
+python3 xsearch.py --query "db:natbib AND mat:eresurser AND mat:bok" --file eresurser
+```
+
+This will download the results [of this API call](http://libris.kb.se/xsearch?query=db:natbib%20AND%20mat:eresurser&format=json) (looping over the pagination, so all the results) and save them in the file `eresurser.json`.
+
 
 ## Import of Libris edition posts
 


### PR DESCRIPTION
Biblioteksdata2/xsearch.py performs a search in the Libris API using xsearch codes
(http://librishelp.libris.kb.se/help/search_codes_swe.jsp).

Usage:

python3 xsearch.py --query "db:natbib AND mat:eresurser AND mat:bok" --file eresurser

This will download the results of
http://libris.kb.se/xsearch?query=db:natbib%20AND%20mat:eresurser&format=json
(looping over the pagination, so all the results) and save them in the file eresurser.json.