### PR TITLE
Add hack for double quotes in string literals

### DIFF
--- a/Biblioteksdata2/xsearch.py
+++ b/Biblioteksdata2/xsearch.py
@@ -37,6 +37,8 @@ def permissive_json_loads(text):
         except ValueError as exc:
             if exc.msg == 'Invalid \\escape':
                 text = text[:exc.pos] + '\\' + text[exc.pos:]
+            elif exc.msg == "Expecting ',' delimiter":
+                text = text[:exc.pos - 1] + '\\' + text[exc.pos - 1:]
             else:
                 raise
         else:


### PR DESCRIPTION
Escape double quotes in string literals to prevent crashing when harvesting the data.

Task: https://phabricator.wikimedia.org/T240853